### PR TITLE
Bug fixes with TSAL installation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = src tests examples
 
 ACLOCAL_AMFLAGS = -I m4
+libSDL_sound_la_LDFLAGS = -no-undefined
 
 docs:
 	@doxygen Doxyfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 SUBDIRS = src tests examples
 
 ACLOCAL_AMFLAGS = -I m4
-libSDL_sound_la_LDFLAGS = -no-undefined
 
 docs:
 	@doxygen Doxyfile

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ To install the library on your system run `make install` as root.
 ## Running the tests
 
 Use `make check` to run the tests
-Note: at the moment, `make check` fails certain assertions in both 'effects.cpp' and 'mixer.cpp'. Do not worry about this,
-the library will still have been built successfully.
+
+Note: at the moment, `make check` fails certain assertions in both 'effects.cpp' and 'mixer.cpp'. Do not worry about this, the library will still have been built successfully.
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To install the library on your system run `make install` as root.
 ## Running the tests
 
 Use `make check` to run the tests
+Note: at the moment, `make check` fails certain assertions in both 'effects.cpp' and 'mixer.cpp'. Do not worry about this,
+the library will still have been built successfully.
 
 ## Built With
 

--- a/include/RouteDevice.hpp
+++ b/include/RouteDevice.hpp
@@ -71,7 +71,7 @@ void RouteDevice<DeviceType>::getOutput(AudioBuffer<float> &buffer) {
       buffer[i] += routedInput->buffer[i];
     }
   }
-};
+}
 
 template <typename DeviceType>
 void RouteDevice<DeviceType>::setMixer(Mixer* mixer) {

--- a/include/Timing.hpp
+++ b/include/Timing.hpp
@@ -13,7 +13,7 @@ class Timing {
     enum NoteScale {
       TICK = 0,
       EIGHTH = 8,
-      QUATER = 4,
+      QUARTER = 4,
       HALF = 2,
       WHOLE = 1,
     };

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -21,7 +21,7 @@ class Util {
     template <typename T>
     static MidiNote scaleToNote(T value, std::pair<T, T> valueRange, std::pair<MidiNote, MidiNote> noteRange) {
       return static_cast<MidiNote> (noteRange.first + ((noteRange.second - noteRange.first) * ((double) value / (valueRange.second - valueRange.first))));
-    };
+    }
     static double ampToDb(double amplitude);
     static double dbToAmp(double db);
     static double volumeToDb(double volume);

--- a/include/tsf.h
+++ b/include/tsf.h
@@ -56,7 +56,7 @@ extern "C" {
 #ifdef TSF_STATIC
 #define TSFDEF static
 #else
-#define TSFDEF extern
+#define TSFDEF inline
 #endif
 
 // The load functions will return a pointer to a struct tsf which all functions

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,7 @@ libtsal_la_SOURCES = \
 includedir=${prefix}/include/tsal
 include_HEADERS = \
   $(top_srcdir)/include/tsal.hpp \
-  $(top_srcdir)/include/tsf.hpp \
+  $(top_srcdir)/include/tsf.h \
   $(top_srcdir)/include/AudioBuffer.hpp \
   $(top_srcdir)/include/Binasc.h \
   $(top_srcdir)/include/Buffer.hpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,9 +29,12 @@ libtsal_la_SOURCES = \
 includedir=${prefix}/include/tsal
 include_HEADERS = \
   $(top_srcdir)/include/tsal.hpp \
+  $(top_srcdir)/include/tsf.hpp \
+  $(top_srcdir)/include/AudioBuffer.hpp \
   $(top_srcdir)/include/Binasc.h \
   $(top_srcdir)/include/Buffer.hpp \
   $(top_srcdir)/include/Channel.hpp \
+  $(top_srcdir)/include/ChannelDevice.hpp \
   $(top_srcdir)/include/Compressor.hpp \
   $(top_srcdir)/include/Delay.hpp \
   $(top_srcdir)/include/Effect.hpp \
@@ -55,5 +58,6 @@ include_HEADERS = \
   $(top_srcdir)/include/SoundFont.hpp \
 	$(top_srcdir)/include/Synth.hpp \
 	$(top_srcdir)/include/ThreadSynth.hpp \
+  $(top_srcdir)/include/Timing.hpp \
   $(top_srcdir)/include/Util.hpp
 


### PR DESCRIPTION
I added a note in the README about how 'make check' fails two assertions; for now, I've only fixed up issues with the general installation process and not the testing portion. You can decide whether this note should remain in the README.

I don't know if this makes much of a different, but I changed the spelling typo in 'Timing.hpp' from "QUATER" to "QUARTER" - I couldn't find any instances of "QUATER" in the src, tests, or examples, but if you know of any, feel free to let me know so I can change them.